### PR TITLE
Fix #11: Returns error instead of panic on missing configuration

### DIFF
--- a/mysqlplugin/mysqlplugin.go
+++ b/mysqlplugin/mysqlplugin.go
@@ -150,7 +150,7 @@ func (p *MySQLPlugin) init(cfg interface{}) error {
 	cfgItems, err := config.GetConfigItems(cfg, "mysql_connection_string", "mysql_use_innodb")
 
 	if err != nil {
-		panic(fmt.Errorf("plugin initalization failed : [%v]", err))
+		return fmt.Errorf("plugin initalization failed : [%v]", err)
 	}
 
 	sqlStats, err := makeStats(cfgItems["mysql_connection_string"].(string))


### PR DESCRIPTION
Instead of panic'ing on missing config items, returns the error so that snapd can provide this info to the user.

