### PR TITLE
For derived values send nil on the first measurement

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-mysql",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v69",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -14,72 +14,146 @@
 			"Rev": "7c7f556282622f94213bc028b4d0a7b6151ba239"
 		},
 		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
+		},
+		{
 			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
 			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/rpc",
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/grpc/common",
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-16-g0f39cf7",
-			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+			"Comment": "v1-7-g32d9c27",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2/hpack",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/internal/timeseries",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/trace",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
+			"Rev": "7f918dd405547ecb864d14a8ecbbfe205b5f930f"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/codes",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/credentials",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/grpclog",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/internal",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/metadata",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/naming",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/peer",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/transport",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,7 +1,7 @@
 # snap collector plugin - mysql
 
 ## Collected Metrics
-his plugin has the ability to gather the following metrics:
+This plugin has the ability to gather the following metrics:
 
 Namespace | Description
 ----------|-----------------------
@@ -127,4 +127,4 @@ Namespace | Description
 /intel/mysql/mysql_commands/[subnamespace] | Available namespaces are evaluated in runtime, metrics indicate the number of times each statement has been executed.  The variable [subnamespace] means the command name.
 /intel/mysql/mysql_handler/[subnamespace] | Available namespaces are evaluated in runtime, metrics indicate the number of internal operations. The variable [subnamespace] means the operation name.
 
-The list of available metrics might be vary depending on the MySQL version or the system configuration.
+Notice, that the list of available metrics might vary depending on the MySQL version or the system configuration.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Loaded Time: Fri, 20 Nov 2015 11:41:39 PST
 
 Create a task:
 ```
-$ $SNAP_PATH/bin/snapctl task create -t examples/tasks/mem-file.json
+$ $SNAP_PATH/bin/snapctl task create -t examples/tasks/task.json
 Using task manifest to create task
 Task created
 ID: 02dd7ff4-8106-47e9-8b86-70067cd0a850

--- a/examples/configs/config.json
+++ b/examples/configs/config.json
@@ -1,22 +1,14 @@
 {
     "control": {
-        "cache_ttl": "5s"
-    },
-    "scheduler": {
-        "default_deadline": "5s",
-        "worker_pool_size": 5
-    },
-    "plugins": {
-        "collector": {
-	    "mysql": {
-                "all": {
-                    "mysql_connection_string": "root:test@tcp(localhost:3306)",
-	                "mysql_use_innodb": false
+        "plugins": {
+            "collector": {
+                "mysql": {
+                    "all": {
+                        "mysql_connection_string": "myuser:mypasswd@tcp(localhost:3306)/",
+			 "mysql_use_innodb": true
+                    }
                 }
             }
-
-        },
-        "publisher": {},
-        "processor": {}
+        }
     }
 }

--- a/examples/tasks/task_all.json
+++ b/examples/tasks/task_all.json
@@ -7,9 +7,7 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/mysql/threads/running": {},
-                "/intel/mysql/mysql_commands/alter_tablespace": {},
-                "/intel/mysql/operations/innodb_rwlock_s_spin_rounds": {}
+                "/intel/mysql/*": {}
             },
             "config": {},
             "process": null,

--- a/mysqlplugin/mysqlplugin.go
+++ b/mysqlplugin/mysqlplugin.go
@@ -38,7 +38,7 @@ const (
 	// Name of plugin
 	Name = "mysql"
 	// Version of plugin
-	Version = 3
+	Version = 4
 	// Type of plugin
 	Type = plugin.CollectorPluginType
 )
@@ -47,10 +47,8 @@ const (
 type MySQLPlugin struct {
 	initialized      bool
 	initializedMutex *sync.Mutex
-
-	callDiscovery map[string]int
-
-	mysql collector
+	callDiscovery    map[string]int
+	mysql            collector
 }
 
 // New returns initialized instance of MySQL Plugin collector
@@ -58,7 +56,6 @@ func New() *MySQLPlugin {
 	self := new(MySQLPlugin)
 	self.initializedMutex = new(sync.Mutex)
 	self.callDiscovery = map[string]int{}
-
 	return self
 }
 

--- a/mysqlplugin/mysqlplugin_test.go
+++ b/mysqlplugin/mysqlplugin_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -20,20 +22,19 @@ limitations under the License.
 package mysqlplugin
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/intelsdi-x/snap/control/plugin"
-	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
-	"github.com/intelsdi-x/snap/core/cdata"
-	"github.com/intelsdi-x/snap/core/ctypes"
-
 	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/stretchr/testify/mock"
 
 	"github.com/intelsdi-x/snap-plugin-collector-mysql/stats"
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/core/ctypes"
 )
 
 type nullSqlsource struct {
@@ -142,7 +143,7 @@ func TestGetMetricTypes(t *testing.T) {
 
 			Convey("on stats construction", func() {
 
-				makeStats = func(connectionString string) (mysqlSource, error) { return nil, smthErr }
+				makeStats = func(connectionString string) (mysqlSource, error) { return nil, errors.New("x") }
 
 				_, dut_err := sut.GetMetricTypes(cfg1)
 
@@ -156,7 +157,7 @@ func TestGetMetricTypes(t *testing.T) {
 
 			Convey("on discovery", func() {
 
-				mock.On("Discover").Return(nil, smthErr)
+				mock.On("Discover").Return(nil, errors.New("x"))
 
 				_, dut_err := sut.GetMetricTypes(cfg1)
 
@@ -209,7 +210,7 @@ func TestCollectMetrics(t *testing.T) {
 			}
 
 			mocked.On("Discover").Return([]metric{metric{Name: "aaa/bbb", Call: 1}, metric{Name: "x/y/z", Call: 2}}, nil)
-			mocked.On("Collect", mock.Anything).Return(nil, smthErr)
+			mocked.On("Collect", mock.Anything).Return(nil, errors.New("x"))
 
 			sut.CollectMetrics(mts)
 
@@ -221,7 +222,7 @@ func TestCollectMetrics(t *testing.T) {
 
 			var dut interface{}
 			mocked.On("Discover").Return(metrics10, nil)
-			mocked.On("Collect", mock.Anything).Return(nil, smthErr).Run(func(args mock.Arguments) {
+			mocked.On("Collect", mock.Anything).Return(nil, errors.New("x")).Run(func(args mock.Arguments) {
 				dut = args.Get(0)
 			})
 
@@ -243,7 +244,7 @@ func TestCollectMetrics(t *testing.T) {
 				var dut interface{}
 				*mocked = collectorMock{}
 				mocked.On("Discover").Return(metrics10, nil)
-				mocked.On("Collect", mock.Anything).Return(nil, smthErr).Run(func(args mock.Arguments) {
+				mocked.On("Collect", mock.Anything).Return(nil, errors.New("x")).Run(func(args mock.Arguments) {
 					dut = args.Get(0)
 				})
 
@@ -283,7 +284,7 @@ func TestCollectMetrics(t *testing.T) {
 		Convey("returns error if collection failed", func() {
 
 			mocked.On("Discover").Return(metrics10, nil)
-			mocked.On("Collect", mock.Anything).Return(nil, smthErr)
+			mocked.On("Collect", mock.Anything).Return(nil, errors.New("x"))
 
 			_, dut_err := sut.CollectMetrics(mts10)
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -130,8 +130,8 @@ func New(connectionString string) (*MySQLStats, error) {
 
 }
 
-// GetStatus queries database for status (query is dependendt on mysql version).
-// If query succeeded appriopriate collection of stats is returned, otherwise
+// GetStatus queries database for status (query is dependent on mysql version).
+// If query succeeded appropriate collection of stats is returned, otherwise
 // error is returned.
 func (mysql *MySQLStats) GetStatus(parseInnodb bool) (Stats, error) {
 	rows, err := mysql.stats.Query()
@@ -454,7 +454,7 @@ func (mysql *MySQLStats) GetMasterStatus() (Stats, error) {
 }
 
 // GetSlaveStatus queries database for statistics related to it's slave role.
-// If query succeeded appriopriate collection of stats is returned, otherwise
+// If query succeeded appropriate collection of stats is returned, otherwise
 // error is returned.
 func (mysql *MySQLStats) GetSlaveStatus() (Stats, error) {
 	rows, err := mysql.slave.Query()
@@ -503,7 +503,7 @@ func (mysql *MySQLStats) Close() error {
 }
 
 // parses version string returned by mysql to numeric value.
-// ex. 1.2.3 is conveted to 10203.
+// ex. 1.2.3 is converted to 10203.
 func parseVersion(s string) uint {
 	dotsStr := strings.Split(strings.TrimSpace(s), "-")[0]
 	var a, b, c uint
@@ -532,17 +532,17 @@ func toInt(ifc interface{}) int64 {
 	return reflect.ValueOf(ifc).Convert(reflect.TypeOf(int64(0))).Int()
 }
 
-// counter fills Stat structure appriopriately for counter type.
+// counter fills Stat structure appropriately for counter type.
 func counter(val interface{}) Stat {
 	return Stat{Value: toInt(val), Type: Counter, IsNull: val == nil}
 }
 
-// derive fills Stat structure appriopriately for derive type.
+// derive fills Stat structure appropriately for derive type.
 func derive(val interface{}) Stat {
 	return Stat{Value: toInt(val), Type: Derive, IsNull: val == nil}
 }
 
-// gauge fills Stat structure appriopriately for gauge type.
+// gauge fills Stat structure appropriately for gauge type.
 func gauge(val interface{}) Stat {
 	return Stat{Value: toInt(val), Type: Gauge, IsNull: val == nil}
 }


### PR DESCRIPTION
Fixed  https://github.com/intelsdi-x/snap-plugin-collector-mysql/issues/15

Summary of changes:
- for derives and counters representing a rate of change send a nil on the first measurement (see [mysqlplugin/collector.go#L208] (https://github.com/IzabellaRaulin/snap-plugin-collector-mysql/blob/first_derived_value/mysqlplugin/collector.go#L208)
- for counters added the different behaviour when value<sub>new</sub> < value <sub>old</sub>; in such cases, there is an assumption that the counter “wrapped around” 

plus:
- added exemplary task manifest (collecting the whole set of metrics)
- updated Godeps to the latest snap
- fixed typo mistakes 


Testing done:
- unit tests
- test the following scenario:  
   - create a task (see [task manifest] (examples/tasks/task_all.json)),
  - start the task and observe that for the first measurement derives and counters equal `nil`.
  - stop the task
  - restart the task and verify that the first incoming values (for derives and counters) are `nil`

```
2016-07-08 17:03:19.444262146 +0200 CEST|/intel/mysql/mysql_commands/select|<nil>|tags[plugin_running_on:devmachine]
2016-07-08 17:03:20.449693252 +0200 CEST|/intel/mysql/mysql_commands/select|0.9944374055402553|tags[plugin_running_on:devmachine]
2016-07-08 17:03:21.457116414 +0200 CEST|/intel/mysql/mysql_commands/select|0.992476665613146|tags[plugin_running_on:devmachine]
2016-07-08 17:03:22.445790547 +0200 CEST|/intel/mysql/mysql_commands/select|1.011628651111959|tags[plugin_running_on:devmachine]

//here the task was stopped

2016-07-08 17:11:46.877977933 +0200 CEST|/intel/mysql/mysql_commands/select|<nil>|tags[plugin_running_on:iza-devmachine]
2016-07-08 17:11:47.926859027 +0200 CEST|/intel/mysql/mysql_commands/select|0.9519847789286142|tags[plugin_running_on:devmachine]
2016-07-08 17:11:48.924835886 +0200 CEST|/intel/mysql/mysql_commands/select|1.0022810644129085|tags[plugin_running_on:devmachine]
2016-07-08 17:11:49.882429386 +0200 CEST|/intel/mysql/mysql_commands/select|1.045587578698946|tags[plugin_running_on:devmachine]

```



@intelsdi-x/plugin-maintainers 




